### PR TITLE
Don't hardcode make binary name in tests

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -83,6 +83,7 @@ RESULTS = \
 EXTRA_DIST = $(SH_LOG_COMPILER) $(TESTS) $(INPUTS) $(RESULTS) test-paperspecs
 
 AM_TESTS_ENVIRONMENT = \
+	export MAKE=$(MAKE); \
 	export LC_ALL=C; \
 	export prefix=$(prefix); \
 	export sysconfdir=$(sysconfdir); \

--- a/tests/run-test
+++ b/tests/run-test
@@ -95,7 +95,7 @@ function no_home() {
 
 # Make a test installation of paper
 cd ..
-make install DESTDIR="$test_dir"
+${MAKE} install DESTDIR="$test_dir"
 export PATH="$test_dir/$bindir:$PATH"
 cd "$test_dir"
 


### PR DESCRIPTION
Use variable passed to Autotools instead of hardcoding binary name. This fixes running tests on FreeBSD. Thanks to Matthias Andree for debugging this issue.