### PR TITLE
fix x-to-1 invocation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -134,6 +134,9 @@ AC_PATH_PROG([HELP2MAN], [help2man], [help2man])
 CROSS_COMPILING=$cross_compiling
 AC_SUBST([CROSS_COMPILING])
 
+dnl Perl is needed for x-to-1
+AC_PATH_PROG([PERL], [perl], [perl])
+
 dnl Create files
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -37,6 +37,6 @@ paper.1.in: $(abs_top_srcdir)/src/paper.c $(abs_top_srcdir)/src/tbl_opts.h paper
 ## Exit gracefully if $@ is not writeable, such as during distcheck!
 	$(AM_V_GEN)if ( touch $@.w && rm -f $@.w; ) >/dev/null 2>&1; then \
 	  $(top_builddir)/build-aux/x-to-1 \
-		$(PERL) $(HELP2MAN) --no-info --no-discard-stderr \
+		$(PERL) "$(HELP2MAN) --no-info --no-discard-stderr" \
 		$(abs_top_builddir)/src/paper$(EXEEXT) paper.x $@; \
 	fi


### PR DESCRIPTION
With 2.0.9, x-to-1 no longer works properly for two reasons:

1. It depends on perl, via the $PERL var, but this is never set.
2. It depends on specific # of args passed to x-to-1, and if help2man and its options aren't quote-wrapped, it miscounts and tosses a generic error.

This PR adds basic detection of the perl runtime and assignment to $PERL to configure.ac AND quote-wraps the help2man invocation in man/Makefile.am.