### PR TITLE
paperconf: Fix parameter -N

### DIFF
--- a/src/paperconf.c
+++ b/src/paperconf.c
@@ -60,8 +60,6 @@ static void printinfo(const struct paper* paper, int options)
     } else if (options & OPT_UPPERNAME) {
 	if (islower(*papername(paper)))
 	    printf("%c%s", toupper(*papername(paper)), papername(paper) + 1);
-	else
-	    printf_downcase(papername(paper));
 	pr = 1;
     }
 


### PR DESCRIPTION
Hi,

once paperconf was put back into libpaper, parameter -N is broken, because the first letter is always changed into lower case.