### PR TITLE
Tests: Set DYLD_LIBRARY_PATH (fix #52)

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -89,6 +89,7 @@ AM_TESTS_ENVIRONMENT = \
 	export prefix=$(prefix); \
 	export sysconfdir=$(sysconfdir); \
 	export bindir=$(bindir); \
+	export libdir=$(libdir); \
 	export abs_srcdir=$(abs_srcdir); \
 	export DIFF=$(DIFF); \
 	export PATH_CONVERT=$(PATH_CONVERT); \

--- a/tests/run-test
+++ b/tests/run-test
@@ -105,6 +105,7 @@ no_home() {
 cd ..
 ${MAKE} install DESTDIR="$test_dir"
 export PATH="$test_dir/$bindir:$PATH"
+export DYLD_LIBRARY_PATH="$test_dir/$libdir"
 cd "$test_dir"
 
 # Set up paper configuration


### PR DESCRIPTION
This allows the tests to find the just-built copy of libpaper.dylib on macOS when not using --enable-relocatable.