### PR TITLE
Skip paper name detection for Android

### DIFF
--- a/lib/libpaper.c.in.in
+++ b/lib/libpaper.c.in.in
@@ -316,7 +316,7 @@ _GL_ATTRIBUTE_PURE const struct paper *paperwithsize(double pswidth, double pshe
 
 /* Get locale default paper size. */
 static const char *localepapername(void) {
-#if defined LC_PAPER && defined _GNU_SOURCE
+#if defined LC_PAPER && defined _GNU_SOURCE && !defined(__ANDROID__)
     if (setlocale(LC_PAPER, "") != NULL) {
 #define NL_PAPER_GET(x)                                                 \
         ((union { char *string; unsigned word; })nl_langinfo(x)).word


### PR DESCRIPTION
Android's bionic (`langinfo.h`) never define or provide `_NL_PAPER_WIDTH` and `_NL_PAPER_HEIGHT` at all, so there is no such thing `nl_langinfo(_NL_PAPER_WIDTH)`. Libreoffice's `paper.cxx` basically skip that part of locale paper size detection with `&& !defined(ANDROID)`. See: 
https://github.com/LibreOffice/core/blob/7db1150b2c4a9adb993084d2dceedb450781b1dc/i18nutil/source/utility/paper.cxx#L308-L317

Note; libreoffice's `ANDROID` is probably configured by their makefile and will not work for your project `libpaper`, so I patch that to `!defined(__ANDROID__)` and it is a correct one (https://android.googlesource.com/platform/bionic/+/HEAD/docs/defines.md)

It is recognized by Termux devs (resembling a linux distro on Android) at https://github.com/termux/termux-packages/pull/21510