### PR TITLE
Use the system-defined default papersize if the user hasn't set one

### DIFF
--- a/lib/libpaper.c.in.in
+++ b/lib/libpaper.c.in.in
@@ -367,8 +367,6 @@ const char *defaultpapername(void) {
             free(papersize);
         }
     }
-    if (paperstr == NULL)
-        paperstr = localepapername();
     if (paperstr == NULL) {
         char *papersize = file_join(sysconfdir, PAPERSIZE_FILENAME);
         if (papersize != NULL) {
@@ -378,6 +376,8 @@ const char *defaultpapername(void) {
     }
     if (paperstr == NULL && default_paper != NULL)
         paperstr = papername(default_paper);
+    if (paperstr == NULL)
+        paperstr = localepapername();
 
     return paperstr;
 }


### PR DESCRIPTION
Currently neither paper nor paperconf read from /etc/papersize:

 >  $ cat /etc/papersize ; paper ; paperconf 
A4
Letter: 8.5x11 in
letter

> $ strace -e t=openat paperconf
openat(AT_FDCWD, "/etc/ld.so.cache", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/lib/x86_64-linux-gnu/libpaper.so.2", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/lib/x86_64-linux-gnu/libc.so.6", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/etc/paperspecs", O_RDONLY) = 3
openat(AT_FDCWD, "/home/gpiero/.config/paperspecs", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/home/gpiero/.config/papersize", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/lib/locale/locale-archive", O_RDONLY|O_CLOEXEC) = 3
letter
+++ exited with 0 +++

After this commit:

> $ cat /etc/papersize ; paper ; paperconf
A4
A4: 210x297 mm
a4

> $ strace -e t=openat paperconf
openat(AT_FDCWD, "/etc/ld.so.cache", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/lib/x86_64-linux-gnu/libpaper.so.2", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/lib/x86_64-linux-gnu/libc.so.6", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/etc/paperspecs", O_RDONLY) = 3
openat(AT_FDCWD, "/home/gpiero/.config/paperspecs", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/home/gpiero/.config/papersize", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/etc/papersize", O_RDONLY) = 3
a4
+++ exited with 0 +++
